### PR TITLE
chore: DependabotでNodeRuntimeの新バージョンを検知出来るように変更 #23

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,9 @@ updates:
       interval: "daily"
     assignees:
       - "jiro4989"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "jiro4989"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,20 @@
+---
+name: docker
+
+"on":
+  push:
+    paths:
+      - 'Dockerfile'
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'Dockerfile'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test for docker
+        run: npm run test-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16.13.2-alpine
+
+COPY . /app
+WORKDIR /app
+RUN npm ci
+RUN npm run test-coverage
+RUN npm run build

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test-coverage": "react-scripts test --coverage --watchAll=false",
+    "test-docker": "docker build .",
     "eject": "react-scripts eject",
     "format": "prettier --write 'src/**/*.ts' 'src/**/*.tsx'",
     "format-check": "prettier --check 'src/**/*.ts' 'src/**/*.tsx'"


### PR DESCRIPTION
Dependabotで新Nodeバージョンをテストできるように、Dependabotで検知できるDockerfileのテストを追加した。
これでDependabotで新NodeのPRが作られたら、合わせて .node-version を上げればよい

close #23 